### PR TITLE
package.json fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-dom": "16.12.0",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
-    "react-scripts": "3.3.1",
+    "react-scripts": "^3.4.0",
     "reactstrap": "8.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Very cool repo, but currently when you run it you get an error that says 
The "path" argument must be of type string. Received undefined
This is because you need to have "react-scripts": "^3.4.0"